### PR TITLE
Update sharp version

### DIFF
--- a/src/pages/Programming/index.jsx
+++ b/src/pages/Programming/index.jsx
@@ -47,7 +47,7 @@ const ProgrammingContent = () => {
   return (
     <div>
       <p>
-        I started working for <a href="https://www.joinhonor.com">joinhonor.com</a> late October of 2021.
+        I started working for <a href="https://www.joinhonor.com">honor</a> late October of 2021.
         I&apos;m really lucky and happy to be here: all of my colleagues are smart and welcoming,
         my manager is reasonable, empathetic, and honest, and the work I&apos;m doing is fun,
         engaging, and meaningful. It&apos;s great.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,7 +1672,7 @@
   integrity sha512-UJG9foZ86NvLIVy0RMKJ8rwOH5hI4E7f5Xx5GIkKmgtNAQWErisPIVKgfZtAb+EC/KcPhPtI7hbmAEnmNcmFPw==
   dependencies:
     "@parcel/plugin" "2.0.0-nightly.710+10620104"
-    sharp "^0.27.1"
+    sharp "^0.28.0"
 
 "@parcel/transformer-js@2.0.0-nightly.710+10620104":
   version "2.0.0-nightly.710"


### PR DESCRIPTION
The old sharp used by parcel wasn't compatible with macOS, so this is a
manual update to the version.